### PR TITLE
docs: expand package.json keywords for better npm discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,22 @@
   },
   "keywords": [
     "omni",
-    "omni-door"
+    "omni-door",
+    "cli",
+    "scaffold",
+    "boilerplate",
+    "generator",
+    "react",
+    "vue",
+    "spa",
+    "ssr",
+    "component-library",
+    "toolkit",
+    "frontend",
+    "typescript",
+    "webpack",
+    "rollup",
+    "project-template"
   ],
   "author": "bobby.li",
   "license": "MIT",


### PR DESCRIPTION
## Summary
This PR expands the keywords in package.json to improve discoverability on npm.

## Changes
- Added keywords: cli, scaffold, boilerplate, generator, react, vue, spa, ssr, component-library, toolkit, frontend, typescript, webpack, rollup, project-template

## Why
The current keywords (`omni`, `omni-door`) are too limited. Adding more descriptive keywords will help users find this package when searching for related tools on npm.

## Checklist
- [x] No code changes
- [x] Documentation/metadata only