### PR TITLE
docs: update LICENSE copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Bobby Li
+Copyright (c) 2019-2026 Bobby Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Updates the LICENSE copyright year range to reflect the project's active maintenance period.

### Changes

- Updated copyright year from `2019` to `2019-2026`

### Why

The project has been actively maintained since 2019, and the copyright notice should reflect the full period of development and maintenance.