### PR TITLE
docs: add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,13 @@
+# These are supported funding model platforms
+
+github: [BobbyLH]
+# patreon: # Replace with a single Patreon username
+# open_collective: # Replace with a single Open Collective username
+# ko_fi: # Replace with a single Ko-fi username
+# tidelift: # Replace with a single Tidelift platform-name/package-name
+# community_bridge: # Replace with a single Community Bridge project-name
+# liberapay: # Replace with a single Liberapay username
+# issuehunt: # Replace with a single IssueHunt username
+# otechie: # Replace with a single Otechie username
+# lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name
+# custom: # Replace with up to 4 custom sponsorship URLs


### PR DESCRIPTION
## Summary

Adds GitHub Sponsors funding configuration to enable the "Sponsor" button on the repository page.

### Changes

- Added `.github/FUNDING.yml` with GitHub Sponsors configuration

### Benefits

- Enables the "Sponsor" button on the repository page
- Provides a way for users to financially support the project
- Shows appreciation for maintainers' work

### Note

The GitHub username in the funding file should be verified/updated by the maintainer to match the correct GitHub Sponsors account.