### PR TITLE
test: fix duplicate test name and migrate mocha.opts to .mocharc.json

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,6 @@
+{
+  "require": ["ts-node/register"],
+  "spec": "src/**/__test__/*.ts",
+  "reporter": "spec",
+  "timeout": 10000
+}

--- a/mocha.opts
+++ b/mocha.opts
@@ -1,3 +1,0 @@
-# mocha.opts
-  --require ts-node/register src/**/__test__/*.ts
-  --reporter spec

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/commands/commands.js",
   "typings": "lib/commands/commands.d.ts",
   "scripts": {
-    "test": "nyc mocha --opts mocha.opts",
+    "test": "nyc mocha",
     "lint": "eslint src/ --ext .ts --ext .tsx",
     "lint:fix": "eslint src/ --ext .ts --ext .tsx --fix",
     "build": "npm run build:rm && npm run build:tsc && npm run build:copy",

--- a/src/commands/initial/__test__/index.test.ts
+++ b/src/commands/initial/__test__/index.test.ts
@@ -116,8 +116,8 @@ describe('initial preset test', function () {
     expect(cli_entire_react.stylelint).to.be.true;
   });
 
-  it('cli_entire_react checking', function () {
-    expect(cli_entire_react).to.be.an('object');
+  it('cli_pc_react checking', function () {
+    expect(cli_pc_react).to.be.an('object');
 
     expect(cli_pc_react.build).to.be.a('string');
     expect(cli_pc_react.build).to.be.equal('webpack');


### PR DESCRIPTION
## Summary

This PR fixes a test naming bug and modernizes the Mocha configuration.

### Changes

#### 1. Fix duplicate test name (Bug Fix)

In `src/commands/initial/__test__/index.test.ts`, line 119 had a duplicate test name:

**Before:**
```typescript
it('cli_entire_react checking', function () {  // Wrong name!
  expect(cli_entire_react).to.be.an('object');  // Wrong assertion!
  expect(cli_pc_react.build)...  // Actually testing cli_pc_react
```

**After:**
```typescript
it('cli_pc_react checking', function () {  // Correct name
  expect(cli_pc_react).to.be.an('object');  // Correct assertion
  expect(cli_pc_react.build)...
```

#### 2. Migrate mocha.opts to .mocharc.json

The `mocha.opts` file format has been deprecated since Mocha 6.0.0. This PR:

- Creates `.mocharc.json` with the same configuration
- Updates `package.json` test script to use the new config
- Removes the deprecated `mocha.opts` file

**New .mocharc.json:**
```json
{
  "require": ["ts-node/register"],
  "spec": "src/**/__test__/*.ts",
  "reporter": "spec",
  "timeout": 10000
}
```

### Benefits

- Fixes incorrect test case that was testing the wrong preset
- Uses modern Mocha configuration format
- Adds explicit timeout to prevent hanging tests
- Better IDE support for JSON config files